### PR TITLE
3.2.0 - Add volume & stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0 - **Pending**
+
+- Added: Support for volume prop and onVolume callback
+
 # 3.1.0 - 2016-08-28
 
 - Fixed #13: Don't call toggleHowler when initializing or changing src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.2.0 - **Pending**
 
-- Added: Support for volume prop and onVolume callback
+- Added: Support for `volume` prop and `onVolume` callback
+- Added: Support for `stop()` method and `onStop` callback
 
 # 3.1.0 - 2016-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.2.0 - **Pending**
+# 3.2.0 - 2016-10-17
 
 - Added: Support for `volume` prop and `onVolume` callback
 - Added: Support for `stop()` method and `onStop` callback

--- a/README.md
+++ b/README.md
@@ -56,24 +56,35 @@ open http://localhost:3000
 Prop      | Default | Description
 ----      | ------- | -----------
 src       |         | The src of songs for playing. Can be a string or an array
-playing   | true    | Set to `true` or `false` to pause or play the media. This also invoke autoplay on initial load
+playing   | true    | Set to `true` or `false` to pause or play the media. This also invokes autoplay on initial load
 loop      | false   | Set to `true` or `false` to enable/disable loop
 mute      | false   | Set to `true` or `false` to mute/unmute current audio
 volume    | 1.0     | The volume of the specific howl, from `0.0` to `1.0`
 onPlay    | noop    | Called when audio starts or resumes playing
 onPause   | noop    | Called when audio is paused
 onVolume  | noop    | Called when volume is changed
+onStop    | noop    | Called when audio is stopped
 onLoad    | noop    | Called when audio is loaded (buffered)
 onLoadError | noop  | Called when an error occurs whilst attempting to load media
 onEnd     |  noop   | Called when media finishes playing
 
 # Methods
 
-- seek(pos? : Number) Set/get current position of player
-- duration: Get duration of current audio file
+#### duration([id])
+Get the duration of the audio source. Will return 0 until after the `load` event fires.
+* **id**: `Number` `optional` The sound ID to check. Passing an ID will return the duration of the sprite being played on this instance; otherwise, the full source duration is returned.
 
-I only wrapper methods that I need. If you need to use undocumented methods,
-you can access howler instance directly via `howler` method
+#### seek([seek])
+Get/set the position of playback for a sound.
+* **seek**: `Number` `optional` The position to move current playback to (in seconds).
+
+#### stop([id])
+Stops playback of sound, resetting `seek` to `0`.
+* **id**: `Number` `optional` The sound ID. If none is passed, all sounds in group are stopped.
+
+#### Other howler.js methods
+If you need to use other howler.js [methods](https://github.com/goldfire/howler.js#methods)
+that are not included in this wrapper you can access the howler instance directly via `howler`
 
 ```javascript
 import React, { Component } from 'react'
@@ -108,10 +119,10 @@ class App extends Component {
 }
 ```
 
-# Howler global core method
+# Howler global core methods
 
-Howler global methods is avaiable in window scope.
-Please refer to [howler's documentation](https://github.com/goldfire/howler.js/tree/2.0#global-core-methods)
+Howler global methods are avaiable in window scope.
+Please refer to [howler's documentation](https://github.com/goldfire/howler.js#global-methods)
 
 Usage:
 
@@ -131,7 +142,7 @@ npm run lint
 
 # Audio file in examples
 
-I take it from [howler.js demo page](http://goldfirestudios.com/blog/104/howler.js-Modern-Web-Audio-Javascript-Library)
+Taken from [howler.js demo page](http://goldfirestudios.com/blog/104/howler.js-Modern-Web-Audio-Javascript-Library)
 
 Sound file direct link: [sound.ogg](http://goldfirestudios.com/proj/howlerjs/sound.ogg)
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ src       |         | The src of songs for playing. Can be a string or an array
 playing   | true    | Set to `true` or `false` to pause or play the media. This also invoke autoplay on initial load
 loop      | false   | Set to `true` or `false` to enable/disable loop
 mute      | false   | Set to `true` or `false` to mute/unmute current audio
+volume    | 1.0     | The volume of the specific howl, from `0.0` to `1.0`
 onPlay    | noop    | Called when audio starts or resumes playing
 onPause   | noop    | Called when audio is paused
+onVolume  | noop    | Called when volume is changed
 onLoad    | noop    | Called when audio is loaded (buffered)
 onLoadError | noop  | Called when an error occurs whilst attempting to load media
 onEnd     |  noop   | Called when media finishes playing

--- a/examples/react/players/FullControl.js
+++ b/examples/react/players/FullControl.js
@@ -18,6 +18,7 @@ class AutoPlay extends React.Component {
     this.handleOnLoad = this.handleOnLoad.bind(this)
     this.handleOnEnd = this.handleOnEnd.bind(this)
     this.handleOnPlay = this.handleOnPlay.bind(this)
+    this.handleStop = this.handleStop.bind(this)
     this.renderSeekPos = this.renderSeekPos.bind(this)
     this.handleLoopToggle = this.handleLoopToggle.bind(this)
     this.handleMuteToggle = this.handleMuteToggle.bind(this)
@@ -52,6 +53,14 @@ class AutoPlay extends React.Component {
       playing: false
     })
     this.clearRAF()
+  }
+
+  handleStop () {
+    this.player.stop()
+    this.setState({
+      playing: false // Need to update our local state so we don't immediately invoke autoplay
+    })
+    this.renderSeekPos()
   }
 
   handleLoopToggle () {
@@ -95,6 +104,9 @@ class AutoPlay extends React.Component {
         />
         <button onClick={this.handleToggle}>
           {(this.state.playing) ? 'Pause' : 'Play' }
+        </button>
+        <button onClick={this.handleStop}>
+          Stop
         </button>
         <p>{(this.state.loaded) ? 'Loaded' : 'Loading'}</p>
         <p>

--- a/examples/react/players/FullControl.js
+++ b/examples/react/players/FullControl.js
@@ -11,7 +11,8 @@ class AutoPlay extends React.Component {
       playing: false,
       loaded: false,
       loop: false,
-      mute: false
+      mute: false,
+      volume: 1.0
     }
     this.handleToggle = this.handleToggle.bind(this)
     this.handleOnLoad = this.handleOnLoad.bind(this)
@@ -89,6 +90,7 @@ class AutoPlay extends React.Component {
           onEnd={this.handleOnEnd}
           loop={this.state.loop}
           mute={this.state.mute}
+          volume={this.state.volume}
           ref={(ref) => this.player = ref}
         />
         <button onClick={this.handleToggle}>
@@ -117,6 +119,20 @@ class AutoPlay extends React.Component {
               onChange={this.handleMuteToggle}
             />
         </label>
+        <div>
+          <label>
+            <input
+              type='range'
+              min='0'
+              max='1'
+              step='.05'
+              value={this.state.volume}
+              onChange={e => this.setState({volume: parseFloat(e.target.value)})}
+            />
+            <br /> Volume: {this.state.volume}
+          </label>
+        </div>
+
       </div>
     )
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-howler",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A React.js wrapper for howler.js (audio player)",
   "main": "lib/index.js",
   "scripts": {

--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -39,6 +39,7 @@ class ReactHowler extends Component {
         onplay: props.onPlay,
         onpause: props.onPause,
         onvolume: props.onVolume,
+        onstop: props.onStop,
         onload: props.onLoad,
         onloaderror: props.onLoadError
       })
@@ -102,6 +103,19 @@ class ReactHowler extends Component {
       this.howler.pause(id)
     } else {
       this.howler.pause()
+    }
+  }
+
+  /**
+   * Stops playback of sound or group
+   * If no id given, stops all playback
+   * @param {Number} id = undefined [sound of group to pause]
+   */
+  stop (id = undefined) {
+    if (id) {
+      this.howler.stop(id)
+    } else {
+      this.howler.stop()
     }
   }
 
@@ -181,6 +195,7 @@ ReactHowler.propTypes = {
   onPause: PropTypes.func,
   onPlay: PropTypes.func,
   onVolume: PropTypes.func,
+  onStop: PropTypes.func,
   onLoad: PropTypes.func,
   onLoadError: PropTypes.func
 }
@@ -194,6 +209,7 @@ ReactHowler.defaultProps = {
   onPause: noop,
   onPlay: noop,
   onVolume: noop,
+  onStop: noop,
   onLoad: noop,
   onLoadError: noop
 }

--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -34,9 +34,11 @@ class ReactHowler extends Component {
         autoplay: props.playing,
         mute: props.mute,
         loop: props.loop,
+        volume: props.volume,
         onend: props.onEnd,
         onplay: props.onPlay,
         onpause: props.onPause,
+        onvolume: props.onVolume,
         onload: props.onLoad,
         onloaderror: props.onLoadError
       })
@@ -59,6 +61,10 @@ class ReactHowler extends Component {
     (props.playing) ? this.play() : this.pause()
     this.mute(props.mute)
     this.loop(props.loop)
+
+    if (props.volume !== this.props.volume) {
+      this.volume(props.volume)
+    }
 
     if (props.seek !== this.seek()) {
       this.seek(props.seek)
@@ -106,6 +112,15 @@ class ReactHowler extends Component {
    */
   mute (...args) {
     this.howler.mute(...args)
+  }
+
+  /**
+   * Get/set volume of this sound or the group. This method optionally takes 0, 1 or 2 arguments.
+   * @param {Number} [volume] [Volume from 0.0 to 1.0]
+   * @param {Number} [id] [The sound ID. If none is passed, all sounds in group are muted]
+   */
+  volume (...args) {
+    return this.howler.volume(...args)
   }
 
   /**
@@ -161,9 +176,11 @@ ReactHowler.propTypes = {
   playing: PropTypes.bool,
   mute: PropTypes.bool,
   loop: PropTypes.bool,
+  volume: PropTypes.number,
   onEnd: PropTypes.func,
   onPause: PropTypes.func,
   onPlay: PropTypes.func,
+  onVolume: PropTypes.func,
   onLoad: PropTypes.func,
   onLoadError: PropTypes.func
 }
@@ -172,9 +189,11 @@ ReactHowler.defaultProps = {
   playing: true, // Enable autoplay by default
   mute: false,
   loop: false,
+  volume: 1.0,
   onEnd: noop,
   onPause: noop,
   onPlay: noop,
+  onVolume: noop,
   onLoad: noop,
   onLoadError: noop
 }


### PR DESCRIPTION
3.2.0 adds support for the following:

- `volume` and `onVolume` props
- `stop()` method and `onStop` prop

## Waiting on howler.js update

The latest _published_ version of howler.js (2.0.0) includes a bug (goldfire/howler.js#595) that prevents `stop()` from working correctly when the audio is paused. This bug has been fixed in the howler.js master branch but not published on npm. I'd like to wait to publish 3.2.0 until this bug is fixed upstream.

If anyone needs these features before then, let me know and I can publish early with the caveat that stopping while paused will not work.
