### PR TITLE
Change howler require path if test env

### DIFF
--- a/src/howler.js
+++ b/src/howler.js
@@ -1,7 +1,8 @@
 let Howler
 
 if (typeof window !== 'undefined') {
-  Howler = require('howler')
+  const requirePath = ( process.env.NODE_ENV === 'test' ) ? 'howler/dist/howler.core.min' : 'howler';
+  Howler = require(requirePath);
 }
 
 module.exports = Howler


### PR DESCRIPTION
Hi!

Seems there are some issues when using mocha and `require('howler')`. The error `ReferenceError: HowlerGlobal is not defined` happens and the only way to solve this is with `require('howler/dist/howler.core.min')`. I modified the require path based on env. It will be changed only if `test` is set. 