### PR TITLE
feat[ReactHowler] add preload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ open http://localhost:3000
 Prop      | Default | Description
 ----      | ------- | -----------
 src       |         | The src of songs for playing. Can be a string or an array
+preload   | true    | Automatically begin downloading the audio file when the Howl is defined.
 playing   | true    | Set to `true` or `false` to pause or play the media.<br>Setting to `true` on initial load will play the audio immediately after it is loaded
 loop      | false   | Set to `true` or `false` to enable/disable loop
 mute      | false   | Set to `true` or `false` to mute/unmute current audio

--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -185,7 +185,7 @@ class ReactHowler extends Component {
    */
   load () {
     this.howler.load()
-  } 
+  }
 
   /**
    * Only render a placeholder
@@ -204,6 +204,7 @@ ReactHowler.propTypes = {
   playing: PropTypes.bool,
   mute: PropTypes.bool,
   loop: PropTypes.bool,
+  preload: PropTypes.bool,
   volume: PropTypes.number,
   onEnd: PropTypes.func,
   onPause: PropTypes.func,

--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -181,6 +181,13 @@ class ReactHowler extends Component {
   }
 
   /**
+   * load audio file
+   */
+  load () {
+    this.howler.load()
+  } 
+
+  /**
    * Only render a placeholder
    */
   render () {
@@ -212,7 +219,7 @@ ReactHowler.defaultProps = {
   playing: true, // Enable autoplay by default
   format: [],
   mute: false,
-  preload: false,
+  preload: true,
   loop: false,
   volume: 1.0,
   onEnd: noop,

--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -34,6 +34,7 @@ class ReactHowler extends Component {
         format: props.format,
         mute: props.mute,
         loop: props.loop,
+        preload: props.preload,
         volume: props.volume,
         onend: props.onEnd,
         onplay: props.onPlay,
@@ -211,6 +212,7 @@ ReactHowler.defaultProps = {
   playing: true, // Enable autoplay by default
   format: [],
   mute: false,
+  preload: false,
   loop: false,
   volume: 1.0,
   onEnd: noop,


### PR DESCRIPTION
Change-Id: I2ea04a77eaa3b5555551a86974fbac056b71628d

sometimes, we don't nedd preload the audio when I use this on the mobile or some low speed internet, it need add： props.preload = false