### PR TITLE
Prevent seeking if the sound is not loaded

### DIFF
--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -76,7 +76,7 @@ class ReactHowler extends Component {
       this.volume(props.volume)
     }
 
-    if (props.seek !== this.seek()) {
+    if (this.howler.state() !== 'unloaded' && props.seek !== this.seek()) {
       this.seek(props.seek)
     }
   }


### PR DESCRIPTION
On the app I work, I present a list of audio files which are all unloaded to prevent using unnecessary bandwidth. When the seek() function is called on an unloaded sound, Howler throws an error. This commit fix this issue by checking that if the sound is unloaded, the call to "seek" is dismissed. 