### PR TITLE
[suggestion] load sound when props.preload changes to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ open http://localhost:3000
 Prop      | Default | Description
 ----      | ------- | -----------
 src       |         | The sources to the track(s) to be loaded for the sound (URLs or base64 data URIs). These should be in order of preference, howler.js will automatically load the first one that is compatible with the current browser. If your files have no extensions, you will need to explicitly specify the extension using the `format` property. <br> Updating the `src` prop on the fly will destroy any currently playing howler instance and create a new one with the new `src`. Updating other props while keeping the `src` the same will maintain the current howler instance.
-preload   | true    | Automatically begin downloading the audio file when the react-howler is initiated.
+preload   | true    | Set to `true` to begin downloading the audio file if it is not loaded yet.
 playing   | true    | Set to `true` or `false` to pause or play the media.<br>Setting to `true` on initial load will play the audio immediately after it is loaded
 loop      | false   | Set to `true` or `false` to enable/disable loop
 mute      | false   | Set to `true` or `false` to mute/unmute current audio

--- a/examples/react/src/players/NoPreload.js
+++ b/examples/react/src/players/NoPreload.js
@@ -7,10 +7,10 @@ class NoPreload extends React.Component {
     super(props)
 
     this.state = {
-      loadState: 'unloaded',
+      preload: false,
+      loaded: false,
       playing: false
     }
-    this.player = null
     this.handleLoad = this.handleLoad.bind(this)
     this.handlePlay = this.handlePlay.bind(this)
     this.handlePause = this.handlePause.bind(this)
@@ -20,7 +20,9 @@ class NoPreload extends React.Component {
   // If you don't call load(), the audio will be automatically
   // loaded when you set the playing prop to true
   handleLoad () {
-    this.player.load()
+    this.setState({
+      preload: true
+    })
   }
 
   handlePlay () {
@@ -39,13 +41,12 @@ class NoPreload extends React.Component {
     return (
       <div>
         <ReactHowler
-          preload={false}
-          ref={(ref) => (this.player = ref)}
           src={['sound2.ogg', 'sound2.mp3']}
+          preload={this.state.preload}
           playing={this.state.playing}
-          onLoad={() => this.setState({loadState: this.player.howlerState()})}
+          onLoad={() => this.setState({loaded: true})}
         />
-        {this.state.loadState === 'unloaded' &&
+        {!this.state.loaded &&
           <Button className='full' onClick={this.handleLoad}>Load (Optional)</Button>
         }
         <br />

--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -79,6 +79,10 @@ class ReactHowler extends Component {
     if (typeof props.seek !== 'undefined' && props.seek !== this.seek()) {
       this.seek(props.seek)
     }
+
+    if (props.preload && this.howlerState() === 'unloaded') {
+      this.load()
+    }
   }
 
   set howler (howl) {


### PR DESCRIPTION
Hi again guys,

in my app I have a queue of tracks where only the subsequent track should be preloaded and others should not.

It would be very convenient to have an ability to load the track simply by changing `preload` prop.
Currently available option to call `.load` on `ref` as stated in `NoPreload` example is less concise, and such use of `ref`s is discouraged by React ([docs link](https://reactjs.org/docs/refs-and-the-dom.html#dont-overuse-refs)). as far as I understand.