### PR TITLE
toggleHowler: don't `mute` if the prop has not changed

### DIFF
--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -69,8 +69,11 @@ class ReactHowler extends Component {
 
   toggleHowler (props) {
     (props.playing) ? this.play() : this.pause()
-    this.mute(props.mute)
     this.loop(props.loop)
+
+    if (props.mute !== this.props.mute) {
+      this.mute(props.mute)
+    }
 
     if (props.volume !== this.props.volume) {
       this.volume(props.volume)


### PR DESCRIPTION
Hey guys,

when I was playing with `react-howler` and used `fade` feature from `howler` I found an undesirable side-effect that actually looks like a bug to me: howler's `mute` method [causes any fading in progress to abort](https://github.com/goldfire/howler.js/blob/master/src/howler.core.js#L1012).

In its turn, `react-howler` [calls `mute` on each possible props update](https://github.com/thangngoc89/react-howler/blob/5d1b22bc714988b649361b1103ee6beaf7d3f177/src/ReactHowler.js#L72), even when the `mute` param has not changed.

As a result, fade aborts immediately when any update happens.

The PR I propose fixes it.

