### PR TITLE
Include xhrWithCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ mute      | false   | Set to `true` or `false` to mute/unmute current audio
 volume    | 1.0     | The volume of the specific howl, from `0.0` to `1.0`
 html5     | false   | Set to `true` to force HTML5 Audio. This should be used for large audio files so that you don't have to wait for the full file to be downloaded and decoded before playing.
 format    | []      | howler.js automatically detects your file format from the extension, but you may also specify a format in situations where extraction won't work (such as with a SoundCloud stream).
+xhrWithCredentials | false | Set to `true` if you want `withCredentials` flag on XHR request. [see reference](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials).
 onPlay    | noop    | Called when audio starts or resumes playing
 onPause   | noop    | Called when audio is paused
 onVolume  | noop    | Called when volume is changed

--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -34,6 +34,7 @@ class ReactHowler extends Component {
     if (typeof Howl !== 'undefined') { // Check if window is available
       this.howler = new Howl({
         src: props.src,
+        xhrWithCredentials: props.xhrWithCredentials,
         format: props.format,
         mute: props.mute,
         loop: props.loop,
@@ -225,6 +226,7 @@ ReactHowler.propTypes = {
     PropTypes.arrayOf(PropTypes.string)
   ]).isRequired,
   format: PropTypes.arrayOf(PropTypes.string),
+  xhrWithCredentials: PropTypes.bool,
   playing: PropTypes.bool,
   mute: PropTypes.bool,
   loop: PropTypes.bool,
@@ -243,6 +245,7 @@ ReactHowler.propTypes = {
 ReactHowler.defaultProps = {
   playing: true, // Enable autoplay by default
   format: [],
+  xhrWithCredentials: false,
   mute: false,
   preload: true,
   loop: false,


### PR DESCRIPTION
Hi,

I need [`xhrWithCredentials`](https://github.com/goldfire/howler.js#xhrwithcredentials-boolean-false) in howler to be true and noticed the component is not accepting such config. Can we add it?

Many thanks