### PR TITLE
Remove seek prop

### DIFF
--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -81,10 +81,6 @@ class ReactHowler extends Component {
       this.volume(this.props.volume)
     }
 
-    if (typeof this.props.seek !== 'undefined' && this.props.seek !== this.seek()) {
-      this.seek(this.props.seek)
-    }
-
     if (this.props.preload && this.howlerState() === 'unloaded') {
       this.load()
     }


### PR DESCRIPTION
# Description
Removing `props.seek` due to issues in practical use

## Related Issue
#59 

## Type of Change
* Breaking changes
* Does not require update to docs since it wasn't documented anyways