### PR TITLE
Update `rate` in `toggleHowler`

### DIFF
--- a/src/ReactHowler.js
+++ b/src/ReactHowler.js
@@ -84,6 +84,10 @@ class ReactHowler extends Component {
       this.volume(this.props.volume)
     }
 
+    if (prevProps.rate !== this.props.rate) {
+      this.rate(this.props.rate)
+    }
+
     if (this.props.preload && this.howlerState() === 'unloaded') {
       this.load()
     }


### PR DESCRIPTION
Currently updating the `rate` prop after initial render has no effect. It looks like this is because [`componentDidUpdate` calls `toggleHowler`](https://github.com/thangngoc89/react-howler/blob/master/src/ReactHowler.js#L22) and `toggleHowler` does not call `this.rate` [like it does with `this.volume`](https://github.com/thangngoc89/react-howler/blob/master/src/ReactHowler.js#L83-L85).

This updates `toggleHowler` to add the appropriate call to `this.rate` when the new `rate` prop differs from the previous prop.